### PR TITLE
ApiKey removed from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,3 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
-
-#Api Key
-src/ApiKey.jsx
-src/FirebaseConfig.jsx

--- a/src/ApiKey.jsx
+++ b/src/ApiKey.jsx
@@ -1,0 +1,10 @@
+const options = {
+    method: 'GET',
+    headers: {
+      'X-RapidAPI-Key': 'f070a4eaefmsh6a2cea4e901d65bp1dac56jsne1ade9b4f78d',
+      'X-RapidAPI-Host': 'streaming-availability.p.rapidapi.com'
+    }
+  };
+const sourceUrl = 'https://streaming-availability.p.rapidapi.com/';
+
+export {options, sourceUrl};


### PR DESCRIPTION
Necessary for autodeploy of site to work